### PR TITLE
Minor fixing and improvements of options

### DIFF
--- a/bin/gifme
+++ b/bin/gifme
@@ -67,7 +67,7 @@ unless system("which convert 2>&1 > /dev/null")
   exit(1)
 end
 
-unless files
+unless files && files.size != 0
   puts parser.help
   exit(1)
 end

--- a/bin/gifme
+++ b/bin/gifme
@@ -11,7 +11,8 @@ options = {
   :reverse  => false,
   :width    => 500,
   :delay    => 20,
-  :cloudapp => system("which cloudapp 2>&1 > /dev/null")
+  :cloudapp => system("which cloudapp 2>&1 > /dev/null"),
+  :quiet    => false,
 }
 
 parser = OptionParser.new do |opts|
@@ -44,6 +45,10 @@ parser = OptionParser.new do |opts|
   opts.on("-v", "--version", "Shows the program version") do
     puts "gifme " + opts.version
     exit
+  end
+  
+  opts.on("-q", "--quiet", "Don't print status messages to stdout") do
+    options[:quiet] = true
   end
   
   opts.on("-h", "--help", "Show this message") do
@@ -98,13 +103,17 @@ end
 cmd << options[:output]
 
 if system(*cmd)
-  puts "You now have a handsome animation at #{options[:output]}"
+  unless options[:quiet]
+    puts "You now have a handsome animation at #{options[:output]}"
+  end
 else
   puts "Something broke when we were animating your gif. Shit."
   exit(1)
-end
+end  
 
 if options[:cloudapp]
-  puts "Now we're uploading it to CloudApp"
-  system "cloudapp #{options[:output]}"
+  unless options[:quiet]
+    puts "Now we're uploading it to CloudApp"
+    system "cloudapp #{options[:output]}"
+  end
 end

--- a/bin/gifme
+++ b/bin/gifme
@@ -15,6 +15,7 @@ options = {
 }
 
 parser = OptionParser.new do |opts|
+  opts.version = "0.0.8"
   opts.banner = "Usage: gifme [options] FILES"
 
   opts.separator ""
@@ -39,7 +40,12 @@ parser = OptionParser.new do |opts|
   opts.on("-w", "--width PIXELS", "Set the width of the image (default is 500px)") do |width|
     options[:width] = width
   end
-
+  
+  opts.on("-v", "--version", "Shows the program version") do
+    puts "gifme " + opts.version
+    exit
+  end
+  
   opts.on("-h", "--help", "Show this message") do
     puts opts
     exit

--- a/bin/gifme
+++ b/bin/gifme
@@ -17,7 +17,7 @@ options = {
 
 parser = OptionParser.new do |opts|
   opts.version = "0.0.8"
-  opts.banner = "Usage: gifme [options] FILES"
+  opts.banner = "Usage: gifme [-h] [-r] [-o /path/to/output] [-d DELAY] [-w PIXELS] [-q] [-v] FILES [FILES ...]"
 
   opts.separator ""
   opts.separator "  FILES can be listed out, like `file1.jpg file2.jpg`, or it"


### PR DESCRIPTION
This pull request fix/add the following:
- Add -v option for show program version.

Example:

<pre>
  $ gifme -v
  gifme 0.0.8
</pre>

- Add -q option for silence program output
- Fix bug with zero arguments that produces nil:NilClass (NoMethodError)

Before to fixing it displays:

<pre>
$ gifme
/var/lib/gems/1.9.1/gems/gifme-0.0.8/bin/gifme:65:in `<top (required)>': undefined method `[]' for nil:NilClass (NoMethodError)
    from /usr/local/bin/gifme:23:in `load'
    from /usr/local/bin/gifme:23:in `<main>'
</pre>


Nows shows the usage and help.
- Improve usage message displaying the options

The current ouput is like:

<pre>
$ gifme -h
Usage: gifme [-h] [-r] [-o /path/to/output] [-d DELAY] [-w PIXELS] [-q] [-v] FILES [FILES ...]

  FILES can be listed out, like `file1.jpg file2.jpg`, or it
  can be a normal shell glob, like `*.jpg`.

Options:
    -r, --reverse                    Reverse the GIF to make it loopable
    -o, --output /path/to/output     Set the animation's output directory
    -d, --delay DELAY                Set the delay between frames (default: 20)
    -w, --width PIXELS               Set the width of the image (default is 500px)
    -v, --version                    Shows the program version
    -q, --quiet                      Don't print status messages to stdout
    -h, --help                       Show this message
</pre>


Happy gifming!
